### PR TITLE
feat: add custom color support

### DIFF
--- a/cmd/color/cmd.go
+++ b/cmd/color/cmd.go
@@ -83,6 +83,11 @@ rong color green --dry-run --json | jq
 			}
 		}
 
+		customs, err := material.GenerateCustomColors(colorMap["primary"])
+		if err != nil {
+			return err
+		}
+
 		// dynamic base16 generation is not possible with single source color
 		viper.Set("base16.method", "static")
 		based, err := base16.Generate(colorMap, nil)
@@ -90,7 +95,7 @@ rong color green --dry-run --json | jq
 			return err
 		}
 
-		output := models.NewOutput("", based, colorMap)
+		output := models.NewOutput("", based, colorMap, customs)
 
 		if viper.GetBool("json") {
 			json.NewEncoder(os.Stdout).Encode(output)

--- a/cmd/image/cmd.go
+++ b/cmd/image/cmd.go
@@ -94,12 +94,17 @@ var Command = &cobra.Command{
 			return fmt.Errorf("failed to generate colors: %w", err)
 		}
 
+		customs, err := material.GenerateCustomColors(colorMap["primary"])
+		if err != nil {
+			return err
+		}
+
 		based, err := base16.Generate(colorMap, wu)
 		if err != nil {
 			return err
 		}
 
-		output := models.NewOutput(imagePath, based, colorMap)
+		output := models.NewOutput(imagePath, based, colorMap, customs)
 
 		if viper.GetBool("json") {
 			if err := json.NewEncoder(os.Stdout).Encode(output); err != nil {

--- a/cmd/regen/cmd.go
+++ b/cmd/regen/cmd.go
@@ -51,6 +51,11 @@ var Command = &cobra.Command{
 			return fmt.Errorf("failed to generate colors: %w", err)
 		}
 
+		customs, err := material.GenerateCustomColors(colorMap["primary"])
+		if err != nil {
+			return err
+		}
+
 		based, err := base16.Generate(colorMap, wu)
 		if err != nil {
 			return err
@@ -64,7 +69,7 @@ var Command = &cobra.Command{
 			}
 		}
 
-		output := models.NewOutput(path, based, colorMap)
+		output := models.NewOutput(path, based, colorMap, customs)
 
 		if viper.GetBool("json") {
 			if err := json.NewEncoder(os.Stdout).Encode(output); err != nil {

--- a/cmd/video/cmd.go
+++ b/cmd/video/cmd.go
@@ -96,6 +96,11 @@ rong video path/to/image.mp4 --dry-run --json | jq
 			return fmt.Errorf("failed to generate colors: %w", err)
 		}
 
+		customs, err := material.GenerateCustomColors(colorMap["primary"])
+		if err != nil {
+			return err
+		}
+
 		based, err := base16.Generate(colorMap, wu)
 		if err != nil {
 			return err
@@ -109,7 +114,7 @@ rong video path/to/image.mp4 --dry-run --json | jq
 			slog.Info("Using generated preview", "path", path)
 		}
 
-		output := models.NewOutput(path, based, colorMap)
+		output := models.NewOutput(path, based, colorMap, customs)
 
 		if viper.GetBool("json") {
 			if err := json.NewEncoder(os.Stdout).Encode(output); err != nil {

--- a/internal/material/custom.go
+++ b/internal/material/custom.go
@@ -1,0 +1,87 @@
+package material
+
+import (
+	"fmt"
+	"regexp"
+
+	blendPkg "github.com/Nadim147c/material/v2/blend"
+	"github.com/Nadim147c/material/v2/color"
+	"github.com/spf13/viper"
+)
+
+// CustomColor is colors generated from user defined colors.
+type CustomColor struct {
+	Color            color.ARGB
+	OnColor          color.ARGB
+	ColorContainer   color.ARGB
+	OnColorContainer color.ARGB
+}
+
+var nameRe = regexp.MustCompile("^([A-Za-z0-9_])+$")
+
+func init() {
+	viper.SetDefault("material.custom.blend", true)
+	viper.SetDefault("material.custom.ratio", 0.35)
+}
+
+// GenerateCustomColors returns all custom colors
+func GenerateCustomColors(primary color.ARGB) (map[string]CustomColor, error) {
+	defined := viper.GetStringMapString("material.custom.colors")
+	if len(defined) == 0 {
+		return map[string]CustomColor{}, nil
+	}
+	m := make(map[string]CustomColor, len(defined))
+	dark := viper.GetBool("dark")
+	blend := viper.GetBool("material.custom.blend")
+	ratio := viper.GetFloat64("material.custom.ratio")
+
+	for name, col := range defined {
+		if !nameRe.MatchString(name) {
+			return nil, fmt.Errorf(
+				"custom color name should only contains alphanumeric values or underscore: name=%s",
+				name,
+			)
+		}
+		argb, err := color.ARGBFromHex(col)
+		if err != nil {
+			return nil, err
+		}
+		m[name] = createCustomColor(argb, primary, dark, blend, ratio)
+	}
+	return m, nil
+}
+
+func createCustomColor(
+	src, to color.ARGB,
+	dark, blend bool,
+	ratio float64,
+) CustomColor {
+	var hct color.Hct
+
+	if blend {
+		hct = blendPkg.HctHueDirect(src, to, ratio)
+	} else {
+		hct = src.ToHct()
+	}
+
+	if dark {
+		return CustomColor{
+			Color:            tone(hct, 40),
+			OnColor:          tone(hct, 100),
+			ColorContainer:   tone(hct, 90),
+			OnColorContainer: tone(hct, 10),
+		}
+	}
+	return CustomColor{
+		Color:            tone(hct, 80),
+		OnColor:          tone(hct, 20),
+		ColorContainer:   tone(hct, 30),
+		OnColorContainer: tone(hct, 90),
+	}
+}
+
+// tone creates an ARGB color from hct color with given tone (brightness).
+func tone(hct color.Hct, tone float64) color.ARGB {
+	hct.Tone = tone
+	return hct.ToARGB()
+}


### PR DESCRIPTION
## Custom colors support

### Config

Custom colors can be defined in the configuration file under the `material.custom` object:

```json
{
  "material": {
    "contrast": 0.0,
    "custom": {
      "ratio": 0.35,
      "blend": true,
      "colors": {
        "orange": "#FFA500",
        "purple": "#800080"
      }
    },
    "platform": "phone",
    "variant": "expressive",
    "version": "2025"
  }
}
```

`blend` indicates whether the defined colors should be blended toward the primary color.
`ratio` specifies the blend amount. A ratio of `0` means no blending, and a ratio of `1` means the color becomes the primary color.

### Templates

In templates, custom colors appear as part of the color array. Looping over them produces output like:

```gotmpl
{{ range .Colors -}}
export {{ .Name.Snake | upper }}="{{ .Color }}"
{{ end -}}
```

Example:

```
... other colors
export ON_PURPLE="#FFFFFF"
export ON_PURPLE_CONTAINER="#FFFFFF"
export PURPLE="#8E38A3"
export PURPLE_CONTAINER="#FDD6FF"
```

Direct access by key is also supported:

```gotmpl
{{ .Customs.purple }}                   // Same as .Custom.purple.Color.HexRGB
{{ .Customs.purple.Color }}             // Hex value
{{ .Customs.purple.OnColor }}           // Hex value
{{ .Customs.purple.OnColorContainer }}  // Hex value
{{ .Customs.purple.ColorContainer.RGB }} // e.g. rgb(24,204,232)
```

Issue: #15

It needs bit more testing...